### PR TITLE
Added support for Gen5 instances with NVME storage

### DIFF
--- a/modules/lx-autoscale/variables.tf
+++ b/modules/lx-autoscale/variables.tf
@@ -37,25 +37,25 @@ variable "AppScriptUrl" {
 
 variable "AppVolumeDevice" {
   type        = "string"
-  description = "(Optional) Device to mount an extra EBS volume. Leave blank to launch without an extra application volume"
-  default     = ""
+  description = "Decision whether to mount an extra EBS volume. Leave as default (\"false\") to launch without an extra application volume"
+  default     = "false"
 }
 
 variable "AppVolumeMountPath" {
   type        = "string"
-  description = "Filesystem path to mount the extra app volume. Ignored if AppVolumeDevice is blank"
+  description = "Filesystem path to mount the extra app volume. Ignored if AppVolumeDevice is false"
   default     = "/opt/data"
 }
 
 variable "AppVolumeType" {
   type        = "string"
-  description = "Type of EBS volume to create. Ignored if AppVolumeDevice is blank"
+  description = "Type of EBS volume to create. Ignored if AppVolumeDevice is false"
   default     = "gp2"
 }
 
 variable "AppVolumeSize" {
   type        = "string"
-  description = "Size in GB of the EBS volume to create. Ignored if AppVolumeDevice is blank"
+  description = "Size in GB of the EBS volume to create. Ignored if AppVolumeDevice is false"
   default     = "1"
 }
 

--- a/modules/lx-autoscale/watchmaker-lx-autoscale.cfn.json
+++ b/modules/lx-autoscale/watchmaker-lx-autoscale.cfn.json
@@ -46,17 +46,13 @@
         },
         "AppVolumeDevice" :
         {
-            "Description" : "(Optional) Device to mount an extra EBS volume. Leave blank to launch without an extra application volume",
+            "Description" : "Decision whether to mount an extra EBS volume. Leave as default (\"false\") to launch without an extra application volume",
             "Type" : "String",
-            "Default" : "",
+            "Default" : "false",
             "AllowedValues" :
             [
-                "",
-                "/dev/xvdf",
-                "/dev/xvdg",
-                "/dev/xvdh",
-                "/dev/xvdi",
-                "/dev/xvdj"
+                "true",
+                "false"
             ]
         },
         "AppVolumeMountPath" :
@@ -105,10 +101,15 @@
                 "t2.small",
                 "t2.medium",
                 "t2.large",
+                "t2.xlarge",
                 "c4.large",
                 "c4.xlarge",
                 "m4.large",
-                "m4.xlarge"
+                "m4.xlarge",
+                "c5.large",
+                "c5.xlarge",
+                "m5.large",
+                "m5.xlarge"
             ]
         },
         "InstanceRole" :
@@ -287,7 +288,7 @@
         },
         "CreateAppVolume" :
         {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AppVolumeDevice" }, "" ] } ]
+            "Fn::Equals" : [ { "Ref" : "AppVolumeDevice" }, "true" ]
         },
         "UseWamConfig" :
         {
@@ -341,6 +342,74 @@
             "AmazonLinux" : { "DeviceName" : "xvda" },
             "RedHat" : { "DeviceName" : "sda1" },
             "CentOS" : { "DeviceName" : "sda1" }
+        },
+        "InstanceTypeCapabilities" :
+        {
+            "t2.micro" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "t2.small" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "t2.medium" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "t2.large" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "t2.xlarge" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "c4.large" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "c4.xlarge" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "m4.large" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "m4.xlarge" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "c5.large" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/nvme1n1"
+            },
+            "c5.xlarge" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/nvme1n1"
+            },
+            "m5.large" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/nvme1n1"
+            },
+            "m5.xlarge" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/nvme1n1"
+            }
         }
     },
     "Metadata" :
@@ -1011,7 +1080,15 @@
                           [
                               "CreateAppVolume",
                               {
-                                  "DeviceName" : { "Ref" : "AppVolumeDevice" },
+                                  "DeviceName" :
+                                  {
+                                      "Fn::FindInMap" :
+                                      [
+                                          "InstanceTypeCapabilities",
+                                          { "Ref" : "InstanceType"},
+                                          "ExternDeviceName"
+                                      ]
+                                  },
                                   "Ebs" :
                                   {
                                       "VolumeSize" : { "Ref" : "AppVolumeSize" },
@@ -1054,11 +1131,26 @@
                                 { "Fn::Join" : [ "", [
                                     "bootcmd:\n",
                                     "- cloud-init-per instance mkfs-appvolume mkfs -t ext4 ",
-                                    { "Ref" : "AppVolumeDevice" },
+                                    {
+                                        "Fn::FindInMap" :
+                                        [
+                                            "InstanceTypeCapabilities",
+                                            { "Ref" : "InstanceType"},
+                                            "InternDeviceName"
+                                        ]
+                                    },
                                     "\n",
                                     "mounts:\n",
                                     "- [ ",
-                                    { "Ref" : "AppVolumeDevice" }, ", ",
+                                    {
+                                        "Fn::FindInMap" :
+                                        [
+                                            "InstanceTypeCapabilities",
+                                            { "Ref" : "InstanceType"},
+                                            "InternDeviceName"
+                                        ]
+                                    },
+                                    ", ",
                                     { "Ref" : "AppVolumeMountPath" },
                                     " ]\n"
                                 ]]},

--- a/modules/lx-instance/variables.tf
+++ b/modules/lx-instance/variables.tf
@@ -37,25 +37,25 @@ variable "AppScriptUrl" {
 
 variable "AppVolumeDevice" {
   type        = "string"
-  description = "(Optional) Device to mount an extra EBS volume. Leave blank to launch without an extra application volume"
-  default     = ""
+  description = "Decision whether to mount an extra EBS volume. Leave as default (\"false\") to launch without an extra application volume"
+  default     = "false"
 }
 
 variable "AppVolumeMountPath" {
   type        = "string"
-  description = "Filesystem path to mount the extra app volume. Ignored if AppVolumeDevice is blank"
+  description = "Filesystem path to mount the extra app volume. Ignored if AppVolumeDevice is false"
   default     = "/opt/data"
 }
 
 variable "AppVolumeType" {
   type        = "string"
-  description = "Type of EBS volume to create. Ignored if AppVolumeDevice is blank"
+  description = "Type of EBS volume to create. Ignored if AppVolumeDevice is false"
   default     = "gp2"
 }
 
 variable "AppVolumeSize" {
   type        = "string"
-  description = "Size in GB of the EBS volume to create. Ignored if AppVolumeDevice is blank"
+  description = "Size in GB of the EBS volume to create. Ignored if AppVolumeDevice is false"
   default     = "1"
 }
 

--- a/modules/lx-instance/watchmaker-lx-instance.cfn.json
+++ b/modules/lx-instance/watchmaker-lx-instance.cfn.json
@@ -46,29 +46,25 @@
         },
         "AppVolumeDevice" :
         {
-            "Description" : "(Optional) Device to mount an extra EBS volume. Leave blank to launch without an extra application volume",
+            "Description" : "Decision on whether to mount an extra EBS volume. Leave as default (\"false\") to launch without an extra application volume",
             "Type" : "String",
-            "Default" : "",
+            "Default" : "false",
             "AllowedValues" :
             [
-                "",
-                "/dev/xvdf",
-                "/dev/xvdg",
-                "/dev/xvdh",
-                "/dev/xvdi",
-                "/dev/xvdj"
+                "true",
+                "false"
             ]
         },
         "AppVolumeMountPath" :
         {
-            "Description" : "Filesystem path to mount the extra app volume. Ignored if \"AppVolumeDevice\" is blank",
+            "Description" : "Filesystem path to mount the extra app volume. Ignored if \"AppVolumeDevice\" is false",
             "Type" : "String",
             "Default" : "/opt/data",
             "AllowedPattern" : "/.*"
         },
         "AppVolumeType" :
         {
-            "Description" : "Type of EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
+            "Description" : "Type of EBS volume to create. Ignored if \"AppVolumeDevice\" is false",
             "Type" : "String",
             "Default" : "gp2",
             "AllowedValues" :
@@ -82,7 +78,7 @@
         },
         "AppVolumeSize" :
         {
-            "Description" : "Size in GB of the EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
+            "Description" : "Size in GB of the EBS volume to create. Ignored if \"AppVolumeDevice\" is false",
             "Type" : "Number",
             "Default" : "1",
             "MinValue": "1",
@@ -105,10 +101,15 @@
                 "t2.small",
                 "t2.medium",
                 "t2.large",
+                "t2.xlarge",
                 "c4.large",
                 "c4.xlarge",
                 "m4.large",
-                "m4.xlarge"
+                "m4.xlarge",
+                "c5.large",
+                "c5.xlarge",
+                "m5.large",
+                "m5.xlarge"
             ]
         },
         "InstanceRole" :
@@ -270,7 +271,7 @@
         },
         "CreateAppVolume" :
         {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AppVolumeDevice" }, "" ] } ]
+            "Fn::Equals" : [ { "Ref" : "AppVolumeDevice" }, "true" ]
         },
         "UseWamConfig" :
         {
@@ -332,6 +333,74 @@
             "AmazonLinux" : { "DeviceName" : "xvda" },
             "RedHat" : { "DeviceName" : "sda1" },
             "CentOS" : { "DeviceName" : "sda1" }
+        },
+        "InstanceTypeCapabilities" :
+        {
+            "t2.micro" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "t2.small" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "t2.medium" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "t2.large" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "t2.xlarge" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "c4.large" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "c4.xlarge" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "m4.large" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "m4.xlarge" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/xvdf"
+            },
+            "c5.large" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/nvme1n1"
+            },
+            "c5.xlarge" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/nvme1n1"
+            },
+            "m5.large" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/nvme1n1"
+            },
+            "m5.xlarge" :
+            {
+                "ExternDeviceName" : "/dev/xvdf",
+                "InternDeviceName" : "/dev/nvme1n1"
+            }
         }
     },
     "Metadata" :
@@ -981,7 +1050,15 @@
                         [
                             "CreateAppVolume",
                             {
-                                "DeviceName" : { "Ref" : "AppVolumeDevice" },
+                                "DeviceName" :
+                                {
+                                    "Fn::FindInMap" :
+                                    [
+                                        "InstanceTypeCapabilities",
+                                        { "Ref" : "InstanceType"},
+                                        "ExternDeviceName"
+                                    ]
+                                },
                                 "Ebs" :
                                 {
                                     "VolumeSize" : { "Ref" : "AppVolumeSize" },
@@ -1046,11 +1123,26 @@
                                 { "Fn::Join" : [ "", [
                                     "bootcmd:\n",
                                     "- cloud-init-per instance mkfs-appvolume mkfs -t ext4 ",
-                                    { "Ref" : "AppVolumeDevice" },
+                                    {
+                                        "Fn::FindInMap" :
+                                        [
+                                            "InstanceTypeCapabilities",
+                                            { "Ref" : "InstanceType"},
+                                            "InternDeviceName"
+                                        ]
+                                    },
                                     "\n",
                                     "mounts:\n",
                                     "- [ ",
-                                    { "Ref" : "AppVolumeDevice" }, ", ",
+                                    {
+                                        "Fn::FindInMap" :
+                                        [
+                                            "InstanceTypeCapabilities",
+                                            { "Ref" : "InstanceType"},
+                                            "InternDeviceName"
+                                        ]
+                                    },
+                                    ", ",
                                     { "Ref" : "AppVolumeMountPath" },
                                     " ]\n"
                                 ]]},

--- a/modules/win-autoscale/watchmaker-win-autoscale.cfn.json
+++ b/modules/win-autoscale/watchmaker-win-autoscale.cfn.json
@@ -76,10 +76,15 @@
                 "t2.small",
                 "t2.medium",
                 "t2.large",
+                "t2.xlarge",
                 "c4.large",
                 "c4.xlarge",
                 "m4.large",
-                "m4.xlarge"
+                "m4.xlarge",
+                "c5.large",
+                "c5.xlarge",
+                "m5.large",
+                "m5.xlarge"
             ]
         },
         "InstanceRole" :

--- a/modules/win-instance/watchmaker-win-instance.cfn.json
+++ b/modules/win-instance/watchmaker-win-instance.cfn.json
@@ -76,10 +76,15 @@
                 "t2.small",
                 "t2.medium",
                 "t2.large",
+                "t2.xlarge",
                 "c4.large",
                 "c4.xlarge",
                 "m4.large",
-                "m4.xlarge"
+                "m4.xlarge",
+                "c5.large",
+                "c5.xlarge",
+                "m5.large",
+                "m5.xlarge"
             ]
         },
         "InstanceRole" :


### PR DESCRIPTION
Incorporated @ferricoxide changes [(PR#493)](https://github.com/plus3it/watchmaker/pull/493) to enable support for Gen5 instances with NVME block storage in Linux.

For Windows, Gen5 instances were added to the templates with no additional logic.  Adding additional EBS volumes using Gen5 instances still functions as is in Windows Server 2012 and older versions.  Windows Server 2016 will require additional steps for the drive letter to be mapped.  See ["EBS Volumes in Windows 2016"](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/common-issues.html#init-disks-win2k16).  Enhancements to the Windows templates are planned for a future date.

