### PR TITLE
Adds CloudWatch logs configuration to Windows templates

### DIFF
--- a/modules/win-autoscale/main.tf
+++ b/modules/win-autoscale/main.tf
@@ -11,6 +11,7 @@ resource "aws_cloudformation_stack" "watchmaker-win-autoscale" {
     AppVolumeDevice        = "${var.AppVolumeDevice}"
     AppVolumeType          = "${var.AppVolumeType}"
     AppVolumeSize          = "${var.AppVolumeSize}"
+    CloudWatchAgentUrl     = "${var.CloudWatchAgentUrl}"
     KeyPairName            = "${var.KeyPairName}"
     InstanceType           = "${var.InstanceType}"
     InstanceRole           = "${var.InstanceRole}"

--- a/modules/win-autoscale/variables.tf
+++ b/modules/win-autoscale/variables.tf
@@ -139,6 +139,12 @@ variable "WatchmakerAdminGroups" {
   default     = ""
 }
 
+variable "CloudWatchAgentUrl" {
+  type        = "string"
+  description = "(Optional) URL from which to download the CloudWatch Agent install file."
+  default     = "https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip"
+}
+
 variable "CfnEndpointUrl" {
   type        = "string"
   description = "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com"

--- a/modules/win-autoscale/variables.tf
+++ b/modules/win-autoscale/variables.tf
@@ -142,7 +142,7 @@ variable "WatchmakerAdminGroups" {
 variable "CloudWatchAgentUrl" {
   type        = "string"
   description = "(Optional) URL from which to download the CloudWatch Agent install file."
-  default     = "https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip"
+  default     = "s3://amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip"
 }
 
 variable "CfnEndpointUrl" {

--- a/modules/win-autoscale/variables.tf
+++ b/modules/win-autoscale/variables.tf
@@ -141,8 +141,8 @@ variable "WatchmakerAdminGroups" {
 
 variable "CloudWatchAgentUrl" {
   type        = "string"
-  description = "(Optional) URL from which to download the CloudWatch Agent install file."
-  default     = "s3://amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip"
+  description = "(Optional) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip"
+  default     = ""
 }
 
 variable "CfnEndpointUrl" {

--- a/modules/win-autoscale/watchmaker-win-autoscale.cfn.json
+++ b/modules/win-autoscale/watchmaker-win-autoscale.cfn.json
@@ -295,8 +295,8 @@
         },
         "CloudWatchAgentUrl": {
             "AllowedPattern": "^$|^s3://.*$",
-            "Default": "s3:///amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip",
-            "Description": "S3 bucket URL (s3://) to download the CloudWatch Agent install file. Agent is installed by default.  Pass an empty string to disable agent install.",
+            "Default": "",
+            "Description": "(Optional) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip",
             "Type": "String"
         },
         "DesiredCapacity": {
@@ -652,6 +652,100 @@
                                 },
                                 "waitAfterCompletion": "0"
                             }
+                        },
+                        "files": {
+                            "c:\\cfn\\scripts\\AmazonCloudWatchAgent\\aws-cloudwatch-agent-config.json": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "{",
+                                            "    \"logs\": {\n",
+                                            "        \"logs_collected\": {\n",
+                                            "            \"files\": {\n",
+                                            "                \"collect_list\": [\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\ProgramData\\\\Amazon\\\\AmazonCloudWatchAgent\\\\Logs\\\\amazon-cloudwatch-agent.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"cloudwatch_agent_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\cfn\\\\log\\\\cfn-init.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"cloudformation_init_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\Watchmaker\\\\Logs\\\\salt_call.debug.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"salt_call_debug_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\Watchmaker\\\\Logs\\\\watchmaker.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"watchmaker_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    }\n",
+                                            "                ]\n",
+                                            "            }\n",
+                                            "        },\n",
+                                            "        \"log_stream_name\": \"default_logs_{instance_id}\"\n",
+                                            "    }\n",
+                                            "}\n"
+                                        ]
+                                    ]
+                                }
+                            }
                         }
                     },
                     "make-app": {
@@ -851,98 +945,6 @@
                                                 "Ref": "AWS::Region"
                                             },
                                             "\n"
-                                        ]
-                                    ]
-                                }
-                            },
-                            "c:\\cfn\\scripts\\AmazonCloudWatchAgent\\aws-cloudwatch-agent-config.json": {
-                                "content": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "{",
-                                            "    \"logs\": {\n",
-                                            "        \"logs_collected\": {\n",
-                                            "            \"files\": {\n",
-                                            "                \"collect_list\": [\n",
-                                            "                    {\n",
-                                            "                        \"file_path\": \"c:\\\\ProgramData\\\\Amazon\\\\AmazonCloudWatchAgent\\\\Logs\\\\amazon-cloudwatch-agent.log\",\n",
-                                            "                        \"log_group_name\": \"",
-                                            {
-                                                "Fn::If": [
-                                                    "InstallCloudWatchAgent",
-                                                    {
-                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
-                                                    },
-                                                    {
-                                                        "Ref": "AWS::NoValue"
-                                                    }
-                                                ]
-                                            },
-                                            "\",\n",
-                                            "                        \"log_stream_name\": \"cloudwatch_agent_logs_{instance_id}\",\n",
-                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
-                                            "                    },\n",
-                                            "                    {\n",
-                                            "                        \"file_path\": \"c:\\\\cfn\\\\log\\\\cfn-init.log\",\n",
-                                            "                        \"log_group_name\": \"",
-                                            {
-                                                "Fn::If": [
-                                                    "InstallCloudWatchAgent",
-                                                    {
-                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
-                                                    },
-                                                    {
-                                                        "Ref": "AWS::NoValue"
-                                                    }
-                                                ]
-                                            },
-                                            "\",\n",
-                                            "                        \"log_stream_name\": \"cloudformation_init_logs_{instance_id}\",\n",
-                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
-                                            "                    },\n",
-                                            "                    {\n",
-                                            "                        \"file_path\": \"c:\\\\Watchmaker\\\\Logs\\\\salt_call.debug.log\",\n",
-                                            "                        \"log_group_name\": \"",
-                                            {
-                                                "Fn::If": [
-                                                    "InstallCloudWatchAgent",
-                                                    {
-                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
-                                                    },
-                                                    {
-                                                        "Ref": "AWS::NoValue"
-                                                    }
-                                                ]
-                                            },
-                                            "\",\n",
-                                            "                        \"log_stream_name\": \"salt_call_debug_logs_{instance_id}\",\n",
-                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
-                                            "                    },\n",
-                                            "                    {\n",
-                                            "                        \"file_path\": \"c:\\\\Watchmaker\\\\Logs\\\\watchmaker.log\",\n",
-                                            "                        \"log_group_name\": \"",
-                                            {
-                                                "Fn::If": [
-                                                    "InstallCloudWatchAgent",
-                                                    {
-                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
-                                                    },
-                                                    {
-                                                        "Ref": "AWS::NoValue"
-                                                    }
-                                                ]
-                                            },
-                                            "\",\n",
-                                            "                        \"log_stream_name\": \"watchmaker_logs_{instance_id}\",\n",
-                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
-                                            "                    }\n",
-                                            "                ]\n",
-                                            "            }\n",
-                                            "        },\n",
-                                            "        \"log_stream_name\": \"default_logs_{instance_id}\"\n",
-                                            "    }\n",
-                                            "}\n"
                                         ]
                                     ]
                                 }

--- a/modules/win-autoscale/watchmaker-win-autoscale.cfn.json
+++ b/modules/win-autoscale/watchmaker-win-autoscale.cfn.json
@@ -975,7 +975,7 @@
                                             "# Install python\n",
                                             "& \"$BootstrapFile\" -PythonUrl \"$PythonUrl\" -Verbose -ErrorAction Stop\n\n",
                                             "# Install watchmaker\n",
-                                            "pip install --index-url=\"$PypiUrl\" --trusted-host=\"$PypiHost\" --upgrade pip setuptools boto3 watchmaker\n\n"
+                                            "pip install --index-url=\"$PypiUrl\" --trusted-host=\"$PypiHost\" --upgrade setuptools boto3 watchmaker\n\n"
                                         ]
                                     ]
                                 }

--- a/modules/win-autoscale/watchmaker-win-autoscale.cfn.json
+++ b/modules/win-autoscale/watchmaker-win-autoscale.cfn.json
@@ -294,9 +294,9 @@
             "Type": "String"
         },
         "CloudWatchAgentUrl": {
-            "AllowedPattern": "^$|^http[s]?://.*$|^s3://.*$",
-            "Default": "https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip",
-            "Description": "(Optional) URL from which to download the CloudWatch Agent install file.",
+            "AllowedPattern": "^$|^s3://.*$",
+            "Default": "s3:///amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip",
+            "Description": "S3 bucket URL (s3://) to download the CloudWatch Agent install file. Agent is installed by default.  Pass an empty string to disable agent install.",
             "Type": "String"
         },
         "DesiredCapacity": {
@@ -493,6 +493,15 @@
                     "configSets": {
                         "launch": [
                             "setup",
+                            {
+                                "Fn::If": [
+                                    "InstallCloudWatchAgent",
+                                    "install-cloudwatch-agent",
+                                    {
+                                        "Ref": "AWS::NoValue"
+                                    }
+                                ]
+                            },
                             "watchmaker-launch",
                             {
                                 "Fn::If": [
@@ -598,6 +607,53 @@
                             }
                         }
                     },
+                    "install-cloudwatch-agent": {
+                        "commands": {
+                            "10-install-cloudwatch-agent": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            {
+                                                "Fn::FindInMap": [
+                                                    "ShellCommandMap",
+                                                    "powershell",
+                                                    "command"
+                                                ]
+                                            },
+                                            " \"& { ",
+                                            "$CloudWatchAgentUri = [System.Uri]'",
+                                            {
+                                                "Ref": "CloudWatchAgentUrl"
+                                            },
+                                            "'; ",
+                                            "$CloudWatchAgentScriptDir = 'c:\\cfn\\scripts\\AmazonCloudWatchAgent'; ",
+                                            "$CloudWatchAgentZipFile = Join-Path $CloudWatchAgentScriptDir $CloudWatchAgentUri.Segments[($CloudWatchAgentUri.Segments.Length-1)]; ",
+                                            "$Null = New-Item $CloudWatchAgentScriptDir -Type Directory -Force; ",
+                                            "Read-S3Object",
+                                            " -BucketName $CloudWatchAgentUri.Host",
+                                            " -Key ($CloudWatchAgentUri.Segments[1..($CloudWatchAgentUri.Segments.Length-1)] -Join '')",
+                                            " -File $CloudWatchAgentZipFile",
+                                            " -Region ",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            "; ",
+                                            "$CloudWatchAgentInstallScript =  \"$CloudWatchAgentScriptDir\"+'\\install.ps1';",
+                                            "$CloudWatchAgentConfig =  \"$CloudWatchAgentScriptDir\"+'\\aws-cloudwatch-agent-config.json';",
+                                            " Expand-Archive -Path $CloudWatchAgentZipFile -DestinationPath $CloudWatchAgentScriptDir;",
+                                            "Push-Location -Path $CloudWatchAgentScriptDir;",
+                                            "iex $CloudWatchAgentInstallScript;",
+                                            ".\\amazon-cloudwatch-agent-ctl.ps1 -a fetch-config -m ec2 -c file:$CloudWatchAgentConfig -s;",
+                                            "Pop-Location",
+                                            "}\""
+                                        ]
+                                    ]
+                                },
+                                "waitAfterCompletion": "0"
+                            }
+                        }
+                    },
                     "make-app": {
                         "commands": {
                             "10-make-app": {
@@ -671,43 +727,6 @@
                                                     "if (Test-Path $EC2LaunchInitDiskConfig) {",
                                                     "iex $EC2LaunchInitDiskScript;",
                                                     "} }",
-                                                    "}\""
-                                                ]
-                                            ]
-                                        },
-                                        ""
-                                    ]
-                                },
-                                "waitAfterCompletion": "0"
-                            },
-                            "11-cloudwatch-agent-install": {
-                                "command": {
-                                    "Fn::If": [
-                                        "InstallCloudWatchAgent",
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    {
-                                                        "Fn::FindInMap": [
-                                                            "ShellCommandMap",
-                                                            "powershell",
-                                                            "command"
-                                                        ]
-                                                    },
-                                                    " \"& { ",
-                                                    "$CloudWatchAgentZipFile = 'c:\\cfn\\scripts\\AmazonCloudWatchAgent.zip';",
-                                                    "$CloudWatchAgentDir = 'c:\\cfn\\scripts\\AmazonCloudWatchAgent';",
-                                                    "$CloudWatchAgentInstallScript =  \"$CloudWatchAgentDir\"+'\\install.ps1';",
-                                                    "$CloudWatchAgentConfig =  \"$CloudWatchAgentDir\"+'\\aws-cloudwatch-agent-config.json';",
-                                                    "if (Test-Path $CloudWatchAgentZipFile) {",
-                                                    " Expand-Archive -Path $CloudWatchAgentZipFile -DestinationPath $CloudWatchAgentDir;",
-                                                    "if (Test-Path $CloudWatchAgentInstallScript) {",
-                                                    "Push-Location -Path $CloudWatchAgentDir;",
-                                                    "iex $CloudWatchAgentInstallScript;",
-                                                    ".\\amazon-cloudwatch-agent-ctl.ps1 -a fetch-config -m ec2 -c file:$CloudWatchAgentConfig -s;",
-                                                    "Pop-Location",
-                                                    " } }",
                                                     "}\""
                                                 ]
                                             ]
@@ -836,17 +855,6 @@
                                     ]
                                 }
                             },
-                            "c:\\cfn\\scripts\\AmazonCloudWatchAgent.zip": {
-                                "source": {
-                                    "Fn::If": [
-                                        "InstallCloudWatchAgent",
-                                        {
-                                            "Ref": "CloudWatchAgentUrl"
-                                        },
-                                        ""
-                                    ]
-                                }
-                            },
                             "c:\\cfn\\scripts\\AmazonCloudWatchAgent\\aws-cloudwatch-agent-config.json": {
                                 "content": {
                                     "Fn::Join": [
@@ -859,24 +867,80 @@
                                             "                \"collect_list\": [\n",
                                             "                    {\n",
                                             "                        \"file_path\": \"c:\\\\ProgramData\\\\Amazon\\\\AmazonCloudWatchAgent\\\\Logs\\\\amazon-cloudwatch-agent.log\",\n",
+                                            "                        \"log_group_name\": \"",
                                             {
-                                                "Fn::Sub": "         \"log_group_name\": \"${WatchmakerLaunchConfigLogGroup}\",\n"
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
                                             },
+                                            "\",\n",
                                             "                        \"log_stream_name\": \"cloudwatch_agent_logs_{instance_id}\",\n",
                                             "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
                                             "                    },\n",
                                             "                    {\n",
                                             "                        \"file_path\": \"c:\\\\cfn\\\\log\\\\cfn-init.log\",\n",
+                                            "                        \"log_group_name\": \"",
                                             {
-                                                "Fn::Sub": "         \"log_group_name\": \"${WatchmakerLaunchConfigLogGroup}\",\n"
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
                                             },
+                                            "\",\n",
                                             "                        \"log_stream_name\": \"cloudformation_init_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\Watchmaker\\\\Logs\\\\salt_call.debug.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"salt_call_debug_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\Watchmaker\\\\Logs\\\\watchmaker.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"watchmaker_logs_{instance_id}\",\n",
                                             "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
                                             "                    }\n",
                                             "                ]\n",
                                             "            }\n",
                                             "        },\n",
-                                            "        \"log_stream_name\": \"default_stream_{instance_id}\"\n",
+                                            "        \"log_stream_name\": \"default_logs_{instance_id}\"\n",
                                             "    }\n",
                                             "}\n"
                                         ]

--- a/modules/win-autoscale/watchmaker-win-autoscale.cfn.json
+++ b/modules/win-autoscale/watchmaker-win-autoscale.cfn.json
@@ -49,6 +49,18 @@
                 }
             ]
         },
+        "InstallCloudWatchAgent": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "CloudWatchAgentUrl"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
         "Reboot": {
             "Fn::Not": [
                 {
@@ -209,6 +221,7 @@
                     },
                     "Parameters": [
                         "CfnEndpointUrl",
+                        "CloudWatchAgentUrl",
                         "ToggleCfnInitUpdate",
                         "ToggleNewInstances"
                     ]
@@ -278,6 +291,12 @@
             "AllowedPattern": "^$|^http[s]?://.*$",
             "Default": "https://cloudformation.us-east-1.amazonaws.com",
             "Description": "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
+            "Type": "String"
+        },
+        "CloudWatchAgentUrl": {
+            "AllowedPattern": "^$|^http[s]?://.*$|^s3://.*$",
+            "Default": "https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip",
+            "Description": "(Optional) URL from which to download the CloudWatch Agent install file.",
             "Type": "String"
         },
         "DesiredCapacity": {
@@ -660,6 +679,43 @@
                                     ]
                                 },
                                 "waitAfterCompletion": "0"
+                            },
+                            "11-cloudwatch-agent-install": {
+                                "command": {
+                                    "Fn::If": [
+                                        "InstallCloudWatchAgent",
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    {
+                                                        "Fn::FindInMap": [
+                                                            "ShellCommandMap",
+                                                            "powershell",
+                                                            "command"
+                                                        ]
+                                                    },
+                                                    " \"& { ",
+                                                    "$CloudWatchAgentZipFile = 'c:\\cfn\\scripts\\AmazonCloudWatchAgent.zip';",
+                                                    "$CloudWatchAgentDir = 'c:\\cfn\\scripts\\AmazonCloudWatchAgent';",
+                                                    "$CloudWatchAgentInstallScript =  \"$CloudWatchAgentDir\"+'\\install.ps1';",
+                                                    "$CloudWatchAgentConfig =  \"$CloudWatchAgentDir\"+'\\aws-cloudwatch-agent-config.json';",
+                                                    "if (Test-Path $CloudWatchAgentZipFile) {",
+                                                    " Expand-Archive -Path $CloudWatchAgentZipFile -DestinationPath $CloudWatchAgentDir;",
+                                                    "if (Test-Path $CloudWatchAgentInstallScript) {",
+                                                    "Push-Location -Path $CloudWatchAgentDir;",
+                                                    "iex $CloudWatchAgentInstallScript;",
+                                                    ".\\amazon-cloudwatch-agent-ctl.ps1 -a fetch-config -m ec2 -c file:$CloudWatchAgentConfig -s;",
+                                                    "Pop-Location",
+                                                    " } }",
+                                                    "}\""
+                                                ]
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                "waitAfterCompletion": "0"
                             }
                         },
                         "files": {
@@ -776,6 +832,53 @@
                                                 "Ref": "AWS::Region"
                                             },
                                             "\n"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "c:\\cfn\\scripts\\AmazonCloudWatchAgent.zip": {
+                                "source": {
+                                    "Fn::If": [
+                                        "InstallCloudWatchAgent",
+                                        {
+                                            "Ref": "CloudWatchAgentUrl"
+                                        },
+                                        ""
+                                    ]
+                                }
+                            },
+                            "c:\\cfn\\scripts\\AmazonCloudWatchAgent\\aws-cloudwatch-agent-config.json": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "{",
+                                            "    \"logs\": {\n",
+                                            "        \"logs_collected\": {\n",
+                                            "            \"files\": {\n",
+                                            "                \"collect_list\": [\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\ProgramData\\\\Amazon\\\\AmazonCloudWatchAgent\\\\Logs\\\\amazon-cloudwatch-agent.log\",\n",
+                                            {
+                                                "Fn::Sub": "         \"log_group_name\": \"${WatchmakerLaunchConfigLogGroup}\",\n"
+                                            },
+                                            "                        \"log_stream_name\": \"cloudwatch_agent_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\cfn\\\\log\\\\cfn-init.log\",\n",
+                                            {
+                                                "Fn::Sub": "         \"log_group_name\": \"${WatchmakerLaunchConfigLogGroup}\",\n"
+                                            },
+                                            "                        \"log_stream_name\": \"cloudformation_init_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    }\n",
+                                            "                ]\n",
+                                            "            }\n",
+                                            "        },\n",
+                                            "        \"log_stream_name\": \"default_stream_{instance_id}\"\n",
+                                            "    }\n",
+                                            "}\n"
                                         ]
                                     ]
                                 }
@@ -1200,6 +1303,23 @@
                 }
             },
             "Type": "AWS::AutoScaling::LaunchConfiguration"
+        },
+        "WatchmakerLaunchConfigLogGroup": {
+            "Condition": "InstallCloudWatchAgent",
+            "Properties": {
+                "LogGroupName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "/aws/ec2/win/",
+                            {
+                                "Ref": "AWS::StackName"
+                            }
+                        ]
+                    ]
+                }
+            },
+            "Type": "AWS::Logs::LogGroup"
         }
     }
 }

--- a/modules/win-autoscale/watchmaker-win-autoscale.params.cfn.json
+++ b/modules/win-autoscale/watchmaker-win-autoscale.params.cfn.json
@@ -96,6 +96,10 @@
         "ParameterValue": "__WATCHMAKEROUPATH__"
     },
     {
+        "ParameterKey": "CloudWatchAgentUrl",
+        "ParameterValue": "__CWAGENTURL__"
+    },
+    {
         "ParameterKey": "CfnEndpointUrl",
         "ParameterValue": "__CFNENDPOINTURL__"
     },

--- a/modules/win-instance/main.tf
+++ b/modules/win-instance/main.tf
@@ -11,6 +11,7 @@ resource "aws_cloudformation_stack" "watchmaker-win-instance" {
     AppVolumeDevice        = "${var.AppVolumeDevice}"
     AppVolumeType          = "${var.AppVolumeType}"
     AppVolumeSize          = "${var.AppVolumeSize}"
+    CloudWatchAgentUrl     = "${var.CloudWatchAgentUrl}"
     KeyPairName            = "${var.KeyPairName}"
     InstanceType           = "${var.InstanceType}"
     InstanceRole           = "${var.InstanceRole}"

--- a/modules/win-instance/variables.tf
+++ b/modules/win-instance/variables.tf
@@ -144,7 +144,7 @@ variable "WatchmakerAdminUsers" {
 variable "CloudWatchAgentUrl" {
   type        = "string"
   description = "(Optional) URL from which to download the CloudWatch Agent install file."
-  default     = "https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip"
+  default     = "s3://amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip"
 }
 
 variable "CfnEndpointUrl" {

--- a/modules/win-instance/variables.tf
+++ b/modules/win-instance/variables.tf
@@ -141,6 +141,12 @@ variable "WatchmakerAdminUsers" {
   default     = ""
 }
 
+variable "CloudWatchAgentUrl" {
+  type        = "string"
+  description = "(Optional) URL from which to download the CloudWatch Agent install file."
+  default     = "https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip"
+}
+
 variable "CfnEndpointUrl" {
   type        = "string"
   description = "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com"

--- a/modules/win-instance/variables.tf
+++ b/modules/win-instance/variables.tf
@@ -143,8 +143,8 @@ variable "WatchmakerAdminUsers" {
 
 variable "CloudWatchAgentUrl" {
   type        = "string"
-  description = "(Optional) URL from which to download the CloudWatch Agent install file."
-  default     = "s3://amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip"
+  description = "(Optional) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip"
+  default     = ""
 }
 
 variable "CfnEndpointUrl" {

--- a/modules/win-instance/watchmaker-win-instance.cfn.json
+++ b/modules/win-instance/watchmaker-win-instance.cfn.json
@@ -335,8 +335,8 @@
         },
         "CloudWatchAgentUrl": {
             "AllowedPattern": "^$|^s3://.*$",
-            "Default": "s3://amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip",
-            "Description": "S3 bucket URL (s3://) to download the CloudWatch Agent install file. Agent is installed by default.  Pass an empty string to disable agent install.",
+            "Default": "",
+            "Description": "(Optional) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip",
             "Type": "String"
         },
         "InstanceRole": {
@@ -637,6 +637,100 @@
                                 },
                                 "waitAfterCompletion": "0"
                             }
+                        },
+                        "files": {
+                            "c:\\cfn\\scripts\\AmazonCloudWatchAgent\\aws-cloudwatch-agent-config.json": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "{",
+                                            "    \"logs\": {\n",
+                                            "        \"logs_collected\": {\n",
+                                            "            \"files\": {\n",
+                                            "                \"collect_list\": [\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\ProgramData\\\\Amazon\\\\AmazonCloudWatchAgent\\\\Logs\\\\amazon-cloudwatch-agent.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerInstanceLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"cloudwatch_agent_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\cfn\\\\log\\\\cfn-init.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerInstanceLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"cloudformation_init_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\Watchmaker\\\\Logs\\\\salt_call.debug.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerInstanceLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"salt_call_debug_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\Watchmaker\\\\Logs\\\\watchmaker.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerInstanceLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"watchmaker_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    }\n",
+                                            "                ]\n",
+                                            "            }\n",
+                                            "        },\n",
+                                            "        \"log_stream_name\": \"default_logs_{instance_id}\"\n",
+                                            "    }\n",
+                                            "}\n"
+                                        ]
+                                    ]
+                                }
+                            }
                         }
                     },
                     "make-app": {
@@ -836,98 +930,6 @@
                                                 "Ref": "AWS::Region"
                                             },
                                             "\n"
-                                        ]
-                                    ]
-                                }
-                            },
-                            "c:\\cfn\\scripts\\AmazonCloudWatchAgent\\aws-cloudwatch-agent-config.json": {
-                                "content": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "{",
-                                            "    \"logs\": {\n",
-                                            "        \"logs_collected\": {\n",
-                                            "            \"files\": {\n",
-                                            "                \"collect_list\": [\n",
-                                            "                    {\n",
-                                            "                        \"file_path\": \"c:\\\\ProgramData\\\\Amazon\\\\AmazonCloudWatchAgent\\\\Logs\\\\amazon-cloudwatch-agent.log\",\n",
-                                            "                        \"log_group_name\": \"",
-                                            {
-                                                "Fn::If": [
-                                                    "InstallCloudWatchAgent",
-                                                    {
-                                                        "Ref": "WatchmakerInstanceLogGroup"
-                                                    },
-                                                    {
-                                                        "Ref": "AWS::NoValue"
-                                                    }
-                                                ]
-                                            },
-                                            "\",\n",
-                                            "                        \"log_stream_name\": \"cloudwatch_agent_logs_{instance_id}\",\n",
-                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
-                                            "                    },\n",
-                                            "                    {\n",
-                                            "                        \"file_path\": \"c:\\\\cfn\\\\log\\\\cfn-init.log\",\n",
-                                            "                        \"log_group_name\": \"",
-                                            {
-                                                "Fn::If": [
-                                                    "InstallCloudWatchAgent",
-                                                    {
-                                                        "Ref": "WatchmakerInstanceLogGroup"
-                                                    },
-                                                    {
-                                                        "Ref": "AWS::NoValue"
-                                                    }
-                                                ]
-                                            },
-                                            "\",\n",
-                                            "                        \"log_stream_name\": \"cloudformation_init_logs_{instance_id}\",\n",
-                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
-                                            "                    },\n",
-                                            "                    {\n",
-                                            "                        \"file_path\": \"c:\\\\Watchmaker\\\\Logs\\\\salt_call.debug.log\",\n",
-                                            "                        \"log_group_name\": \"",
-                                            {
-                                                "Fn::If": [
-                                                    "InstallCloudWatchAgent",
-                                                    {
-                                                        "Ref": "WatchmakerInstanceLogGroup"
-                                                    },
-                                                    {
-                                                        "Ref": "AWS::NoValue"
-                                                    }
-                                                ]
-                                            },
-                                            "\",\n",
-                                            "                        \"log_stream_name\": \"salt_call_debug_logs_{instance_id}\",\n",
-                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
-                                            "                    },\n",
-                                            "                    {\n",
-                                            "                        \"file_path\": \"c:\\\\Watchmaker\\\\Logs\\\\watchmaker.log\",\n",
-                                            "                        \"log_group_name\": \"",
-                                            {
-                                                "Fn::If": [
-                                                    "InstallCloudWatchAgent",
-                                                    {
-                                                        "Ref": "WatchmakerInstanceLogGroup"
-                                                    },
-                                                    {
-                                                        "Ref": "AWS::NoValue"
-                                                    }
-                                                ]
-                                            },
-                                            "\",\n",
-                                            "                        \"log_stream_name\": \"watchmaker_logs_{instance_id}\",\n",
-                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
-                                            "                    }\n",
-                                            "                ]\n",
-                                            "            }\n",
-                                            "        },\n",
-                                            "        \"log_stream_name\": \"default_logs_{instance_id}\"\n",
-                                            "    }\n",
-                                            "}\n"
                                         ]
                                     ]
                                 }

--- a/modules/win-instance/watchmaker-win-instance.cfn.json
+++ b/modules/win-instance/watchmaker-win-instance.cfn.json
@@ -960,7 +960,7 @@
                                             "# Install python\n",
                                             "& \"$BootstrapFile\" -PythonUrl \"$PythonUrl\" -Verbose -ErrorAction Stop\n\n",
                                             "# Install watchmaker\n",
-                                            "pip install --index-url=\"$PypiUrl\" --trusted-host=\"$PypiHost\" --upgrade pip setuptools boto3 watchmaker\n\n"
+                                            "pip install --index-url=\"$PypiUrl\" --trusted-host=\"$PypiHost\" --upgrade setuptools boto3 watchmaker\n\n"
                                         ]
                                     ]
                                 }

--- a/modules/win-instance/watchmaker-win-instance.cfn.json
+++ b/modules/win-instance/watchmaker-win-instance.cfn.json
@@ -268,6 +268,13 @@
             "Value": {
                 "Ref": "WatchmakerInstance"
             }
+        },
+        "WatchmakerInstanceLogGroupName": {
+            "Condition": "InstallCloudWatchAgent",
+            "Description": "Log Group Name",
+            "Value": {
+                "Ref": "WatchmakerInstanceLogGroup"
+            }
         }
     },
     "Parameters": {
@@ -327,9 +334,9 @@
             "Type": "String"
         },
         "CloudWatchAgentUrl": {
-            "AllowedPattern": "^$|^http[s]?://.*$|^s3://.*$",
-            "Default": "https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip",
-            "Description": "(Optional) URL from which to download the CloudWatch Agent install file.",
+            "AllowedPattern": "^$|^s3://.*$",
+            "Default": "s3://amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip",
+            "Description": "S3 bucket URL (s3://) to download the CloudWatch Agent install file. Agent is installed by default.  Pass an empty string to disable agent install.",
             "Type": "String"
         },
         "InstanceRole": {
@@ -471,6 +478,15 @@
                     "configSets": {
                         "launch": [
                             "setup",
+                            {
+                                "Fn::If": [
+                                    "InstallCloudWatchAgent",
+                                    "install-cloudwatch-agent",
+                                    {
+                                        "Ref": "AWS::NoValue"
+                                    }
+                                ]
+                            },
                             "watchmaker-launch",
                             {
                                 "Fn::If": [
@@ -576,6 +592,53 @@
                             }
                         }
                     },
+                    "install-cloudwatch-agent": {
+                        "commands": {
+                            "10-install-cloudwatch-agent": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            {
+                                                "Fn::FindInMap": [
+                                                    "ShellCommandMap",
+                                                    "powershell",
+                                                    "command"
+                                                ]
+                                            },
+                                            " \"& { ",
+                                            "$CloudWatchAgentUri = [System.Uri]'",
+                                            {
+                                                "Ref": "CloudWatchAgentUrl"
+                                            },
+                                            "'; ",
+                                            "$CloudWatchAgentScriptDir = 'c:\\cfn\\scripts\\AmazonCloudWatchAgent'; ",
+                                            "$CloudWatchAgentZipFile = Join-Path $CloudWatchAgentScriptDir $CloudWatchAgentUri.Segments[($CloudWatchAgentUri.Segments.Length-1)]; ",
+                                            "$Null = New-Item $CloudWatchAgentScriptDir -Type Directory -Force; ",
+                                            "Read-S3Object",
+                                            " -BucketName $CloudWatchAgentUri.Host",
+                                            " -Key ($CloudWatchAgentUri.Segments[1..($CloudWatchAgentUri.Segments.Length-1)] -Join '')",
+                                            " -File $CloudWatchAgentZipFile",
+                                            " -Region ",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            "; ",
+                                            "$CloudWatchAgentInstallScript =  \"$CloudWatchAgentScriptDir\"+'\\install.ps1';",
+                                            "$CloudWatchAgentConfig =  \"$CloudWatchAgentScriptDir\"+'\\aws-cloudwatch-agent-config.json';",
+                                            " Expand-Archive -Path $CloudWatchAgentZipFile -DestinationPath $CloudWatchAgentScriptDir;",
+                                            "Push-Location -Path $CloudWatchAgentScriptDir;",
+                                            "iex $CloudWatchAgentInstallScript;",
+                                            ".\\amazon-cloudwatch-agent-ctl.ps1 -a fetch-config -m ec2 -c file:$CloudWatchAgentConfig -s;",
+                                            "Pop-Location",
+                                            "}\""
+                                        ]
+                                    ]
+                                },
+                                "waitAfterCompletion": "0"
+                            }
+                        }
+                    },
                     "make-app": {
                         "commands": {
                             "10-make-app": {
@@ -649,43 +712,6 @@
                                                     "if (Test-Path $EC2LaunchInitDiskConfig) {",
                                                     "iex $EC2LaunchInitDiskScript;",
                                                     "} }",
-                                                    "}\""
-                                                ]
-                                            ]
-                                        },
-                                        ""
-                                    ]
-                                },
-                                "waitAfterCompletion": "0"
-                            },
-                            "11-cloudwatch-agent-install": {
-                                "command": {
-                                    "Fn::If": [
-                                        "InstallCloudWatchAgent",
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    {
-                                                        "Fn::FindInMap": [
-                                                            "ShellCommandMap",
-                                                            "powershell",
-                                                            "command"
-                                                        ]
-                                                    },
-                                                    " \"& { ",
-                                                    "$CloudWatchAgentZipFile = 'c:\\cfn\\scripts\\AmazonCloudWatchAgent.zip';",
-                                                    "$CloudWatchAgentDir = 'c:\\cfn\\scripts\\AmazonCloudWatchAgent';",
-                                                    "$CloudWatchAgentInstallScript =  \"$CloudWatchAgentDir\"+'\\install.ps1';",
-                                                    "$CloudWatchAgentConfig =  \"$CloudWatchAgentDir\"+'\\aws-cloudwatch-agent-config.json';",
-                                                    "if (Test-Path $CloudWatchAgentZipFile) {",
-                                                    " Expand-Archive -Path $CloudWatchAgentZipFile -DestinationPath $CloudWatchAgentDir;",
-                                                    "if (Test-Path $CloudWatchAgentInstallScript) {",
-                                                    "Push-Location -Path $CloudWatchAgentDir;",
-                                                    "iex $CloudWatchAgentInstallScript;",
-                                                    ".\\amazon-cloudwatch-agent-ctl.ps1 -a fetch-config -m ec2 -c file:$CloudWatchAgentConfig -s;",
-                                                    "Pop-Location",
-                                                    " } }",
                                                     "}\""
                                                 ]
                                             ]
@@ -814,17 +840,6 @@
                                     ]
                                 }
                             },
-                            "c:\\cfn\\scripts\\AmazonCloudWatchAgent.zip": {
-                                "source": {
-                                    "Fn::If": [
-                                        "InstallCloudWatchAgent",
-                                        {
-                                            "Ref": "CloudWatchAgentUrl"
-                                        },
-                                        ""
-                                    ]
-                                }
-                            },
                             "c:\\cfn\\scripts\\AmazonCloudWatchAgent\\aws-cloudwatch-agent-config.json": {
                                 "content": {
                                     "Fn::Join": [
@@ -837,18 +852,74 @@
                                             "                \"collect_list\": [\n",
                                             "                    {\n",
                                             "                        \"file_path\": \"c:\\\\ProgramData\\\\Amazon\\\\AmazonCloudWatchAgent\\\\Logs\\\\amazon-cloudwatch-agent.log\",\n",
+                                            "                        \"log_group_name\": \"",
                                             {
-                                                "Fn::Sub": "         \"log_group_name\": \"${WatchmakerInstanceLogGroup}\",\n"
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerInstanceLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
                                             },
+                                            "\",\n",
                                             "                        \"log_stream_name\": \"cloudwatch_agent_logs_{instance_id}\",\n",
                                             "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
                                             "                    },\n",
                                             "                    {\n",
                                             "                        \"file_path\": \"c:\\\\cfn\\\\log\\\\cfn-init.log\",\n",
+                                            "                        \"log_group_name\": \"",
                                             {
-                                                "Fn::Sub": "         \"log_group_name\": \"${WatchmakerInstanceLogGroup}\",\n"
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerInstanceLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
                                             },
+                                            "\",\n",
                                             "                        \"log_stream_name\": \"cloudformation_init_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\Watchmaker\\\\Logs\\\\salt_call.debug.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerInstanceLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"salt_call_debug_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\Watchmaker\\\\Logs\\\\watchmaker.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerInstanceLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"watchmaker_logs_{instance_id}\",\n",
                                             "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
                                             "                    }\n",
                                             "                ]\n",

--- a/modules/win-instance/watchmaker-win-instance.cfn.json
+++ b/modules/win-instance/watchmaker-win-instance.cfn.json
@@ -61,6 +61,18 @@
                 }
             ]
         },
+        "InstallCloudWatchAgent": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "CloudWatchAgentUrl"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
         "Reboot": {
             "Fn::Not": [
                 {
@@ -238,6 +250,7 @@
                     },
                     "Parameters": [
                         "CfnEndpointUrl",
+                        "CloudWatchAgentUrl",
                         "ToggleCfnInitUpdate"
                     ]
                 }
@@ -311,6 +324,12 @@
             "AllowedPattern": "^$|^http[s]?://.*$",
             "Default": "https://cloudformation.us-east-1.amazonaws.com",
             "Description": "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
+            "Type": "String"
+        },
+        "CloudWatchAgentUrl": {
+            "AllowedPattern": "^$|^http[s]?://.*$|^s3://.*$",
+            "Default": "https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/AmazonCloudWatchAgent.zip",
+            "Description": "(Optional) URL from which to download the CloudWatch Agent install file.",
             "Type": "String"
         },
         "InstanceRole": {
@@ -638,6 +657,43 @@
                                     ]
                                 },
                                 "waitAfterCompletion": "0"
+                            },
+                            "11-cloudwatch-agent-install": {
+                                "command": {
+                                    "Fn::If": [
+                                        "InstallCloudWatchAgent",
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    {
+                                                        "Fn::FindInMap": [
+                                                            "ShellCommandMap",
+                                                            "powershell",
+                                                            "command"
+                                                        ]
+                                                    },
+                                                    " \"& { ",
+                                                    "$CloudWatchAgentZipFile = 'c:\\cfn\\scripts\\AmazonCloudWatchAgent.zip';",
+                                                    "$CloudWatchAgentDir = 'c:\\cfn\\scripts\\AmazonCloudWatchAgent';",
+                                                    "$CloudWatchAgentInstallScript =  \"$CloudWatchAgentDir\"+'\\install.ps1';",
+                                                    "$CloudWatchAgentConfig =  \"$CloudWatchAgentDir\"+'\\aws-cloudwatch-agent-config.json';",
+                                                    "if (Test-Path $CloudWatchAgentZipFile) {",
+                                                    " Expand-Archive -Path $CloudWatchAgentZipFile -DestinationPath $CloudWatchAgentDir;",
+                                                    "if (Test-Path $CloudWatchAgentInstallScript) {",
+                                                    "Push-Location -Path $CloudWatchAgentDir;",
+                                                    "iex $CloudWatchAgentInstallScript;",
+                                                    ".\\amazon-cloudwatch-agent-ctl.ps1 -a fetch-config -m ec2 -c file:$CloudWatchAgentConfig -s;",
+                                                    "Pop-Location",
+                                                    " } }",
+                                                    "}\""
+                                                ]
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                "waitAfterCompletion": "0"
                             }
                         },
                         "files": {
@@ -754,6 +810,53 @@
                                                 "Ref": "AWS::Region"
                                             },
                                             "\n"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "c:\\cfn\\scripts\\AmazonCloudWatchAgent.zip": {
+                                "source": {
+                                    "Fn::If": [
+                                        "InstallCloudWatchAgent",
+                                        {
+                                            "Ref": "CloudWatchAgentUrl"
+                                        },
+                                        ""
+                                    ]
+                                }
+                            },
+                            "c:\\cfn\\scripts\\AmazonCloudWatchAgent\\aws-cloudwatch-agent-config.json": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "{",
+                                            "    \"logs\": {\n",
+                                            "        \"logs_collected\": {\n",
+                                            "            \"files\": {\n",
+                                            "                \"collect_list\": [\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\ProgramData\\\\Amazon\\\\AmazonCloudWatchAgent\\\\Logs\\\\amazon-cloudwatch-agent.log\",\n",
+                                            {
+                                                "Fn::Sub": "         \"log_group_name\": \"${WatchmakerInstanceLogGroup}\",\n"
+                                            },
+                                            "                        \"log_stream_name\": \"cloudwatch_agent_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"c:\\\\cfn\\\\log\\\\cfn-init.log\",\n",
+                                            {
+                                                "Fn::Sub": "         \"log_group_name\": \"${WatchmakerInstanceLogGroup}\",\n"
+                                            },
+                                            "                        \"log_stream_name\": \"cloudformation_init_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    }\n",
+                                            "                ]\n",
+                                            "            }\n",
+                                            "        },\n",
+                                            "        \"log_stream_name\": \"default_logs_{instance_id}\"\n",
+                                            "    }\n",
+                                            "}\n"
                                         ]
                                     ]
                                 }
@@ -1285,6 +1388,23 @@
                 }
             },
             "Type": "AWS::EC2::Instance"
+        },
+        "WatchmakerInstanceLogGroup": {
+            "Condition": "InstallCloudWatchAgent",
+            "Properties": {
+                "LogGroupName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "/aws/ec2/win/",
+                            {
+                                "Ref": "AWS::StackName"
+                            }
+                        ]
+                    ]
+                }
+            },
+            "Type": "AWS::Logs::LogGroup"
         }
     }
 }

--- a/modules/win-instance/watchmaker-win-instance.params.cfn.json
+++ b/modules/win-instance/watchmaker-win-instance.params.cfn.json
@@ -92,6 +92,10 @@
         "ParameterValue": "__WATCHMAKEROUPATH__"
     },
     {
+        "ParameterKey": "CloudWatchAgentUrl",
+        "ParameterValue": "__CWAGENTURL__"
+    },
+    {
         "ParameterKey": "CfnEndpointUrl",
         "ParameterValue": "__CFNENDPOINTURL__"
     },


### PR DESCRIPTION
This update adds the installation of the CloudWatch Agent and configures the agent to send logs from`cfn-init.log` and `amazon-cloudwatch-agent.log` to CloudWatch logs.

Summary of changes:
-  Adds variable representing the URL to the CloudWatch agent installation file.
-  Creates a condition variable to determine if installation is needed based on the CloudWatch agent URL variable.
-  Conditionally creates the CloudWatch agent configuration file.
-  Conditionally creates a CloudWatch log group with the stackname appended to the log group name.
-  The instance id is appended to the log stream to help identify source of the logs.

 