### PR TITLE
Added CloudWatch Logs option to Linux templates

### DIFF
--- a/modules/lx-autoscale/main.tf
+++ b/modules/lx-autoscale/main.tf
@@ -14,6 +14,7 @@ resource "aws_cloudformation_stack" "watchmaker-lx-autoscale" {
     AppVolumeMountPath    = "${var.AppVolumeMountPath}"
     AppVolumeType         = "${var.AppVolumeType}"
     AppVolumeSize         = "${var.AppVolumeSize}"
+    CloudWatchAgentUrl    = "${var.CloudWatchAgentUrl}"
     KeyPairName           = "${var.KeyPairName}"
     InstanceType          = "${var.InstanceType}"
     InstanceRole          = "${var.InstanceRole}"

--- a/modules/lx-autoscale/variables.tf
+++ b/modules/lx-autoscale/variables.tf
@@ -158,6 +158,12 @@ variable "WatchmakerAdminUsers" {
   default     = ""
 }
 
+variable "CloudWatchAgentUrl" {
+  type        = "string"
+  description = "(Optional) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/linux/amd64/latest/AmazonCloudWatchAgent.zip"
+  default     = ""
+}
+
 variable "CfnEndpointUrl" {
   type        = "string"
   description = "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com"

--- a/modules/lx-autoscale/watchmaker-lx-autoscale.cfn.json
+++ b/modules/lx-autoscale/watchmaker-lx-autoscale.cfn.json
@@ -45,6 +45,18 @@
                 }
             ]
         },
+        "InstallCloudWatchAgent": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "CloudWatchAgentUrl"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
         "InstallUpdates": {
             "Fn::Not": [
                 {
@@ -290,6 +302,7 @@
                         "CfnEndpointUrl",
                         "CfnGetPipUrl",
                         "CfnBootstrapUtilsUrl",
+                        "CloudWatchAgentUrl",
                         "ToggleCfnInitUpdate",
                         "ToggleNewInstances"
                     ]
@@ -391,6 +404,12 @@
             "AllowedPattern": "^http[s]?://.*\\.py$",
             "Default": "https://bootstrap.pypa.io/get-pip.py",
             "Description": "URL to get-pip.py",
+            "Type": "String"
+        },
+        "CloudWatchAgentUrl": {
+            "AllowedPattern": "^$|^s3://.*$",
+            "Default": "",
+            "Description": "(Optional) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/linux/amd64/latest/AmazonCloudWatchAgent.zip",
             "Type": "String"
         },
         "DesiredCapacity": {
@@ -589,6 +608,15 @@
                     "configSets": {
                         "launch": [
                             "setup",
+                            {
+                                "Fn::If": [
+                                    "InstallCloudWatchAgent",
+                                    "install-cloudwatch-agent",
+                                    {
+                                        "Ref": "AWS::NoValue"
+                                    }
+                                ]
+                            },
                             "watchmaker-install",
                             "watchmaker-launch",
                             {
@@ -701,6 +729,173 @@
                                     ]
                                 },
                                 "ignoreErrors": "true"
+                            }
+                        }
+                    },
+                    "install-cloudwatch-agent": {
+                        "commands": {
+                            "01-get-cloudwatch-agent": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "mkdir -p /etc/cfn/scripts/ &&",
+                                            " aws s3 cp ",
+                                            {
+                                                "Ref": "CloudWatchAgentUrl"
+                                            },
+                                            " /etc/cfn/scripts/AmazonCloudWatchAgent.zip",
+                                            " --region ",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            " &&",
+                                            " chown root:root /etc/cfn/scripts/AmazonCloudWatchAgent.zip &&",
+                                            " chmod 700 /etc/cfn/scripts/AmazonCloudWatchAgent.zip"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "02-extract-cloudwatch-agent": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "yum -y install unzip &&",
+                                            "unzip /etc/cfn/scripts/AmazonCloudWatchAgent.zip -d /etc/cfn/scripts/aws-cw-agent"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "10-install-cloudwatch-agent": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            " bash -xe install.sh &&",
+                                            " systemctl enable amazon-cloudwatch-agent.service &&",
+                                            " systemctl start amazon-cloudwatch-agent.service &&",
+                                            " /opt/aws/amazon-cloudwatch-agent/bin/",
+                                            "amazon-cloudwatch-agent-ctl",
+                                            " -a fetch-config -m ec2 -c",
+                                            " file:/opt/aws/amazon-cloudwatch-agent/etc/",
+                                            "amazon-cloudwatch-agent.json -s"
+                                        ]
+                                    ]
+                                },
+                                "cwd": "/etc/cfn/scripts/aws-cw-agent"
+                            }
+                        },
+                        "files": {
+                            "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "{",
+                                            "    \"logs\": {\n",
+                                            "        \"logs_collected\": {\n",
+                                            "            \"files\": {\n",
+                                            "                \"collect_list\": [\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"cloudwatch_agent_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/var/log/cfn-init.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"cfn_init_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/var/log/messages\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"messages_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/var/log/watchmaker/watchmaker.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"watchmaker_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/var/log/watchmaker/salt_call.debug.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"salt_call_debug_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    }\n",
+                                            "                ]\n",
+                                            "            }\n",
+                                            "        },\n",
+                                            "        \"log_stream_name\": \"default_logs_{instance_id}\"\n",
+                                            "    }\n",
+                                            "}\n"
+                                        ]
+                                    ]
+                                }
                             }
                         }
                     },
@@ -1470,6 +1665,23 @@
                 }
             },
             "Type": "AWS::AutoScaling::LaunchConfiguration"
+        },
+        "WatchmakerLaunchConfigLogGroup": {
+            "Condition": "InstallCloudWatchAgent",
+            "Properties": {
+                "LogGroupName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "/aws/ec2/lx/",
+                            {
+                                "Ref": "AWS::StackName"
+                            }
+                        ]
+                    ]
+                }
+            },
+            "Type": "AWS::Logs::LogGroup"
         }
     }
 }

--- a/modules/lx-autoscale/watchmaker-lx-autoscale.cfn.json
+++ b/modules/lx-autoscale/watchmaker-lx-autoscale.cfn.json
@@ -318,6 +318,27 @@
             }
         }
     },
+    "Outputs": {
+        "WatchmakerAutoScalingGroupId": {
+            "Description": "Autoscaling Group ID",
+            "Value": {
+                "Ref": "WatchmakerAutoScalingGroup"
+            }
+        },
+        "WatchmakerLaunchConfigId": {
+            "Description": "Launch Configuration ID",
+            "Value": {
+                "Ref": "WatchmakerLaunchConfig"
+            }
+        },
+        "WatchmakerLaunchConfigLogGroupName": {
+            "Condition": "InstallCloudWatchAgent",
+            "Description": "Log Group Name",
+            "Value": {
+                "Ref": "WatchmakerLaunchConfigLogGroup"
+            }
+        }
+    },
     "Parameters": {
         "AmiDistro": {
             "AllowedValues": [
@@ -775,11 +796,9 @@
                                             " bash -xe install.sh &&",
                                             " systemctl enable amazon-cloudwatch-agent.service &&",
                                             " systemctl start amazon-cloudwatch-agent.service &&",
-                                            " /opt/aws/amazon-cloudwatch-agent/bin/",
-                                            "amazon-cloudwatch-agent-ctl",
+                                            " /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl",
                                             " -a fetch-config -m ec2 -c",
-                                            " file:/opt/aws/amazon-cloudwatch-agent/etc/",
-                                            "amazon-cloudwatch-agent.json -s"
+                                            " file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
                                         ]
                                     ]
                                 },

--- a/modules/lx-autoscale/watchmaker-lx-autoscale.params.cfn.json
+++ b/modules/lx-autoscale/watchmaker-lx-autoscale.params.cfn.json
@@ -100,6 +100,10 @@
         "ParameterValue": "__WATCHMAKERADMINGROUPS__"
     },
     {
+        "ParameterKey": "CloudWatchAgentUrl",
+        "ParameterValue": "__CWAGENTURL__"
+    },
+    {
         "ParameterKey": "CfnEndpointUrl",
         "ParameterValue": "__CFNENDPOINTURL__"
     },

--- a/modules/lx-instance/main.tf
+++ b/modules/lx-instance/main.tf
@@ -14,6 +14,7 @@ resource "aws_cloudformation_stack" "watchmaker-lx-instance" {
     AppVolumeMountPath     = "${var.AppVolumeMountPath}"
     AppVolumeType          = "${var.AppVolumeType}"
     AppVolumeSize          = "${var.AppVolumeSize}"
+    CloudWatchAgentUrl     = "${var.CloudWatchAgentUrl}"
     KeyPairName            = "${var.KeyPairName}"
     InstanceType           = "${var.InstanceType}"
     InstanceRole           = "${var.InstanceRole}"

--- a/modules/lx-instance/variables.tf
+++ b/modules/lx-instance/variables.tf
@@ -152,6 +152,12 @@ variable "WatchmakerAdminUsers" {
   default     = ""
 }
 
+variable "CloudWatchAgentUrl" {
+  type        = "string"
+  description = "(Optional) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/linux/amd64/latest/AmazonCloudWatchAgent.zip"
+  default     = ""
+}
+
 variable "CfnEndpointUrl" {
   type        = "string"
   description = "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com"

--- a/modules/lx-instance/watchmaker-lx-instance.cfn.json
+++ b/modules/lx-instance/watchmaker-lx-instance.cfn.json
@@ -57,6 +57,18 @@
                 }
             ]
         },
+        "InstallCloudWatchAgent": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "CloudWatchAgentUrl"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
         "InstallUpdates": {
             "Fn::Not": [
                 {
@@ -306,6 +318,7 @@
                         "CfnEndpointUrl",
                         "CfnGetPipUrl",
                         "CfnBootstrapUtilsUrl",
+                        "CloudWatchAgentUrl",
                         "ToggleCfnInitUpdate"
                     ]
                 }
@@ -322,6 +335,13 @@
             "Description": "Instance ID",
             "Value": {
                 "Ref": "WatchmakerInstance"
+            }
+        },
+        "WatchmakerInstanceLogGroupName": {
+            "Condition": "InstallCloudWatchAgent",
+            "Description": "Log Group Name",
+            "Value": {
+                "Ref": "WatchmakerInstanceLogGroup"
             }
         }
     },
@@ -411,6 +431,12 @@
             "AllowedPattern": "^http[s]?://.*\\.py$",
             "Default": "https://bootstrap.pypa.io/get-pip.py",
             "Description": "URL to get-pip.py",
+            "Type": "String"
+        },
+        "CloudWatchAgentUrl": {
+            "AllowedPattern": "^$|^s3://.*$",
+            "Default": "",
+            "Description": "(Optional) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/linux/amd64/latest/AmazonCloudWatchAgent.zip",
             "Type": "String"
         },
         "InstanceRole": {
@@ -549,6 +575,15 @@
                     "configSets": {
                         "launch": [
                             "setup",
+                            {
+                                "Fn::If": [
+                                    "InstallCloudWatchAgent",
+                                    "install-cloudwatch-agent",
+                                    {
+                                        "Ref": "AWS::NoValue"
+                                    }
+                                ]
+                            },
                             "watchmaker-install",
                             "watchmaker-launch",
                             {
@@ -661,6 +696,173 @@
                                     ]
                                 },
                                 "ignoreErrors": "true"
+                            }
+                        }
+                    },
+                    "install-cloudwatch-agent": {
+                        "commands": {
+                            "01-get-cloudwatch-agent": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "mkdir -p /etc/cfn/scripts/ &&",
+                                            " aws s3 cp ",
+                                            {
+                                                "Ref": "CloudWatchAgentUrl"
+                                            },
+                                            " /etc/cfn/scripts/AmazonCloudWatchAgent.zip",
+                                            " --region ",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            " &&",
+                                            " chown root:root /etc/cfn/scripts/AmazonCloudWatchAgent.zip &&",
+                                            " chmod 700 /etc/cfn/scripts/AmazonCloudWatchAgent.zip"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "02-extract-cloudwatch-agent": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "yum -y install unzip &&",
+                                            "unzip /etc/cfn/scripts/AmazonCloudWatchAgent.zip -d /etc/cfn/scripts/aws-cw-agent"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "10-install-cloudwatch-agent": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            " bash -xe install.sh &&",
+                                            " systemctl enable amazon-cloudwatch-agent.service &&",
+                                            " systemctl start amazon-cloudwatch-agent.service &&",
+                                            " /opt/aws/amazon-cloudwatch-agent/bin/",
+                                            "amazon-cloudwatch-agent-ctl",
+                                            " -a fetch-config -m ec2 -c",
+                                            " file:/opt/aws/amazon-cloudwatch-agent/etc/",
+                                            "amazon-cloudwatch-agent.json -s"
+                                        ]
+                                    ]
+                                },
+                                "cwd": "/etc/cfn/scripts/aws-cw-agent"
+                            }
+                        },
+                        "files": {
+                            "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "{",
+                                            "    \"logs\": {\n",
+                                            "        \"logs_collected\": {\n",
+                                            "            \"files\": {\n",
+                                            "                \"collect_list\": [\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerInstanceLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"cloudwatch_agent_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/var/log/cfn-init.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerInstanceLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"cfn_init_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/var/log/messages\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerInstanceLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"messages_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/var/log/watchmaker/watchmaker.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerInstanceLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"watchmaker_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/var/log/watchmaker/salt_call.debug.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerInstanceLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"salt_call_debug_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    }\n",
+                                            "                ]\n",
+                                            "            }\n",
+                                            "        },\n",
+                                            "        \"log_stream_name\": \"default_logs_{instance_id}\"\n",
+                                            "    }\n",
+                                            "}\n"
+                                        ]
+                                    ]
+                                }
                             }
                         }
                     },
@@ -1495,6 +1697,23 @@
                 }
             },
             "Type": "AWS::EC2::Instance"
+        },
+        "WatchmakerInstanceLogGroup": {
+            "Condition": "InstallCloudWatchAgent",
+            "Properties": {
+                "LogGroupName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "/aws/ec2/lx/",
+                            {
+                                "Ref": "AWS::StackName"
+                            }
+                        ]
+                    ]
+                }
+            },
+            "Type": "AWS::Logs::LogGroup"
         }
     }
 }

--- a/modules/lx-instance/watchmaker-lx-instance.cfn.json
+++ b/modules/lx-instance/watchmaker-lx-instance.cfn.json
@@ -742,11 +742,9 @@
                                             " bash -xe install.sh &&",
                                             " systemctl enable amazon-cloudwatch-agent.service &&",
                                             " systemctl start amazon-cloudwatch-agent.service &&",
-                                            " /opt/aws/amazon-cloudwatch-agent/bin/",
-                                            "amazon-cloudwatch-agent-ctl",
+                                            " /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl",
                                             " -a fetch-config -m ec2 -c",
-                                            " file:/opt/aws/amazon-cloudwatch-agent/etc/",
-                                            "amazon-cloudwatch-agent.json -s"
+                                            " file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
                                         ]
                                     ]
                                 },

--- a/modules/lx-instance/watchmaker-lx-instance.params.cfn.json
+++ b/modules/lx-instance/watchmaker-lx-instance.params.cfn.json
@@ -100,6 +100,10 @@
         "ParameterValue": "__WATCHMAKEROUPATH__"
     },
     {
+        "ParameterKey": "CloudWatchAgentUrl",
+        "ParameterValue": "__CWAGENTURL__"
+    },
+    {
         "ParameterKey": "CfnBootstrapUtilsUrl",
         "ParameterValue": "__CFNBOOTSTRAPUTILSURL__"
     },

--- a/modules/win-autoscale/watchmaker-win-autoscale.cfn.json
+++ b/modules/win-autoscale/watchmaker-win-autoscale.cfn.json
@@ -237,6 +237,27 @@
             }
         }
     },
+    "Outputs": {
+        "WatchmakerAutoScalingGroupId": {
+            "Description": "Autoscaling Group ID",
+            "Value": {
+                "Ref": "WatchmakerAutoScalingGroup"
+            }
+        },
+        "WatchmakerLaunchConfigId": {
+            "Description": "Launch Configuration ID",
+            "Value": {
+                "Ref": "WatchmakerLaunchConfig"
+            }
+        },
+        "WatchmakerLaunchConfigLogGroupName": {
+            "Condition": "InstallCloudWatchAgent",
+            "Description": "Log Group Name",
+            "Value": {
+                "Ref": "WatchmakerLaunchConfigLogGroup"
+            }
+        }
+    },
     "Parameters": {
         "AmiId": {
             "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$",


### PR DESCRIPTION
This PR adds, to the Linux Cloudformation templates, the option to enable sending logs from the EC2 resource to CloudWatch Logs.

When enabled, the CloudWatch agent wll be installed and configured to send the following logs:

- CloudWatch logs (/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log)
- Cloudformation Init logs (/var/log/cfn-init.log)
- Messages logs (/var/log/messages)
- Watchmaker logs (/var/log/watchmaker/watchmaker.log)
- Salt Call logs (/var/log/watchmaker/salt_call.debug.log)

