### PR TITLE
Removed unnecessary EL7 commands and optimized CW agent download script

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.1.0
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/modules/lx-autoscale/watchmaker-lx-autoscale.cfn.json
+++ b/modules/lx-autoscale/watchmaker-lx-autoscale.cfn.json
@@ -632,7 +632,7 @@
                             {
                                 "Fn::If": [
                                     "InstallCloudWatchAgent",
-                                    "install-cloudwatch-agent",
+                                    "cloudwatch-agent-install",
                                     {
                                         "Ref": "AWS::NoValue"
                                     }
@@ -694,73 +694,14 @@
                             }
                         ]
                     },
-                    "finalize": {
-                        "commands": {
-                            "10-signal-success": {
-                                "command": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "/opt/aws/bin/cfn-signal -e 0",
-                                            " --stack ",
-                                            {
-                                                "Ref": "AWS::StackName"
-                                            },
-                                            " --resource WatchmakerAutoScalingGroup",
-                                            {
-                                                "Fn::If": [
-                                                    "AssignInstanceRole",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --role ",
-                                                                {
-                                                                    "Ref": "InstanceRole"
-                                                                }
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            {
-                                                "Fn::If": [
-                                                    "UseCfnUrl",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --url ",
-                                                                {
-                                                                    "Ref": "CfnEndpointUrl"
-                                                                }
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            " --region ",
-                                            {
-                                                "Ref": "AWS::Region"
-                                            },
-                                            "\n"
-                                        ]
-                                    ]
-                                },
-                                "ignoreErrors": "true"
-                            }
-                        }
-                    },
-                    "install-cloudwatch-agent": {
+                    "cloudwatch-agent-install": {
                         "commands": {
                             "01-get-cloudwatch-agent": {
                                 "command": {
                                     "Fn::Join": [
                                         "",
                                         [
-                                            "mkdir -p /etc/cfn/scripts/ &&",
+                                            "install -Dbm 700 -o root -g root /dev/null /etc/cfn/scripts/AmazonCloudWatchAgent.zip &&",
                                             " aws s3 cp ",
                                             {
                                                 "Ref": "CloudWatchAgentUrl"
@@ -769,10 +710,7 @@
                                             " --region ",
                                             {
                                                 "Ref": "AWS::Region"
-                                            },
-                                            " &&",
-                                            " chown root:root /etc/cfn/scripts/AmazonCloudWatchAgent.zip &&",
-                                            " chmod 700 /etc/cfn/scripts/AmazonCloudWatchAgent.zip"
+                                            }
                                         ]
                                     ]
                                 }
@@ -913,6 +851,65 @@
                                         ]
                                     ]
                                 }
+                            }
+                        }
+                    },
+                    "finalize": {
+                        "commands": {
+                            "10-signal-success": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "/opt/aws/bin/cfn-signal -e 0",
+                                            " --stack ",
+                                            {
+                                                "Ref": "AWS::StackName"
+                                            },
+                                            " --resource WatchmakerAutoScalingGroup",
+                                            {
+                                                "Fn::If": [
+                                                    "AssignInstanceRole",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --role ",
+                                                                {
+                                                                    "Ref": "InstanceRole"
+                                                                }
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "UseCfnUrl",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --url ",
+                                                                {
+                                                                    "Ref": "CfnEndpointUrl"
+                                                                }
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            " --region ",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                "ignoreErrors": "true"
                             }
                         }
                     },

--- a/modules/lx-autoscale/watchmaker-lx-autoscale.cfn.json
+++ b/modules/lx-autoscale/watchmaker-lx-autoscale.cfn.json
@@ -632,7 +632,7 @@
                             {
                                 "Fn::If": [
                                     "InstallCloudWatchAgent",
-                                    "cloudwatch-agent-install",
+                                    "cw-agent-install",
                                     {
                                         "Ref": "AWS::NoValue"
                                     }
@@ -694,7 +694,7 @@
                             }
                         ]
                     },
-                    "cloudwatch-agent-install": {
+                    "cw-agent-install": {
                         "commands": {
                             "01-get-cloudwatch-agent": {
                                 "command": {

--- a/modules/lx-autoscale/watchmaker-lx-autoscale.cfn.json
+++ b/modules/lx-autoscale/watchmaker-lx-autoscale.cfn.json
@@ -794,8 +794,6 @@
                                         "",
                                         [
                                             " bash -xe install.sh &&",
-                                            " systemctl enable amazon-cloudwatch-agent.service &&",
-                                            " systemctl start amazon-cloudwatch-agent.service &&",
                                             " /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl",
                                             " -a fetch-config -m ec2 -c",
                                             " file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"

--- a/modules/lx-instance/watchmaker-lx-instance.cfn.json
+++ b/modules/lx-instance/watchmaker-lx-instance.cfn.json
@@ -740,8 +740,6 @@
                                         "",
                                         [
                                             " bash -xe install.sh &&",
-                                            " systemctl enable amazon-cloudwatch-agent.service &&",
-                                            " systemctl start amazon-cloudwatch-agent.service &&",
                                             " /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl",
                                             " -a fetch-config -m ec2 -c",
                                             " file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"

--- a/modules/lx-instance/watchmaker-lx-instance.cfn.json
+++ b/modules/lx-instance/watchmaker-lx-instance.cfn.json
@@ -578,7 +578,7 @@
                             {
                                 "Fn::If": [
                                     "InstallCloudWatchAgent",
-                                    "install-cloudwatch-agent",
+                                    "cloudwatch-agent-install",
                                     {
                                         "Ref": "AWS::NoValue"
                                     }
@@ -640,73 +640,14 @@
                             }
                         ]
                     },
-                    "finalize": {
-                        "commands": {
-                            "10-signal-success": {
-                                "command": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "/opt/aws/bin/cfn-signal -e 0",
-                                            " --stack ",
-                                            {
-                                                "Ref": "AWS::StackName"
-                                            },
-                                            " --resource WatchmakerInstance",
-                                            {
-                                                "Fn::If": [
-                                                    "AssignInstanceRole",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --role ",
-                                                                {
-                                                                    "Ref": "InstanceRole"
-                                                                }
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            {
-                                                "Fn::If": [
-                                                    "UseCfnUrl",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --url ",
-                                                                {
-                                                                    "Ref": "CfnEndpointUrl"
-                                                                }
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            " --region ",
-                                            {
-                                                "Ref": "AWS::Region"
-                                            },
-                                            "\n"
-                                        ]
-                                    ]
-                                },
-                                "ignoreErrors": "true"
-                            }
-                        }
-                    },
-                    "install-cloudwatch-agent": {
+                    "cloudwatch-agent-install": {
                         "commands": {
                             "01-get-cloudwatch-agent": {
                                 "command": {
                                     "Fn::Join": [
                                         "",
                                         [
-                                            "mkdir -p /etc/cfn/scripts/ &&",
+                                            "install -Dbm 700 -o root -g root /dev/null /etc/cfn/scripts/AmazonCloudWatchAgent.zip &&",
                                             " aws s3 cp ",
                                             {
                                                 "Ref": "CloudWatchAgentUrl"
@@ -715,10 +656,7 @@
                                             " --region ",
                                             {
                                                 "Ref": "AWS::Region"
-                                            },
-                                            " &&",
-                                            " chown root:root /etc/cfn/scripts/AmazonCloudWatchAgent.zip &&",
-                                            " chmod 700 /etc/cfn/scripts/AmazonCloudWatchAgent.zip"
+                                            }
                                         ]
                                     ]
                                 }
@@ -859,6 +797,65 @@
                                         ]
                                     ]
                                 }
+                            }
+                        }
+                    },
+                    "finalize": {
+                        "commands": {
+                            "10-signal-success": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "/opt/aws/bin/cfn-signal -e 0",
+                                            " --stack ",
+                                            {
+                                                "Ref": "AWS::StackName"
+                                            },
+                                            " --resource WatchmakerInstance",
+                                            {
+                                                "Fn::If": [
+                                                    "AssignInstanceRole",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --role ",
+                                                                {
+                                                                    "Ref": "InstanceRole"
+                                                                }
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "UseCfnUrl",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --url ",
+                                                                {
+                                                                    "Ref": "CfnEndpointUrl"
+                                                                }
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            " --region ",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                "ignoreErrors": "true"
                             }
                         }
                     },

--- a/modules/lx-instance/watchmaker-lx-instance.cfn.json
+++ b/modules/lx-instance/watchmaker-lx-instance.cfn.json
@@ -578,7 +578,7 @@
                             {
                                 "Fn::If": [
                                     "InstallCloudWatchAgent",
-                                    "cloudwatch-agent-install",
+                                    "cw-agent-install",
                                     {
                                         "Ref": "AWS::NoValue"
                                     }
@@ -640,7 +640,7 @@
                             }
                         ]
                     },
-                    "cloudwatch-agent-install": {
+                    "cw-agent-install": {
                         "commands": {
                             "01-get-cloudwatch-agent": {
                                 "command": {


### PR DESCRIPTION
The default CloudWatch agent config script, `amazon-cloudwatch-agent-ctl`, already handles setting up the CloudWatch agent service in EL6 and EL7.  The two systemd commands were not required.

In additon, the CloudWatch agent download steps have been optimized into fewer commands.

This PR addresses the following issues:

#15 
#16 