### PR TITLE
Fixes error when destroying failed stack

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.2
+current_version = 1.4.3
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/modules/lx-autoscale/outputs.tf
+++ b/modules/lx-autoscale/outputs.tf
@@ -17,15 +17,15 @@ output "watchmaker-lx-autoscale-scale-up-scheduled-action" {
 
 output "watchmaker-lx-autoscale-autoscaling-group-id" {
   description = "Autoscaling Group ID"
-  value       = "${aws_cloudformation_stack.watchmaker-lx-autoscale.outputs["WatchmakerAutoScalingGroupId"]}"
+  value       = "${lookup(aws_cloudformation_stack.watchmaker-lx-autoscale.outputs, "WatchmakerAutoScalingGroupId", "")}"
 }
 
 output "watchmaker-lx-autoscale-launch-config-id" {
   description = "Launch Configuration ID"
-  value       = "${aws_cloudformation_stack.watchmaker-lx-autoscale.outputs["WatchmakerLaunchConfigId"]}"
+  value       = "${lookup(aws_cloudformation_stack.watchmaker-lx-autoscale.outputs, "WatchmakerLaunchConfigId", "")}"
 }
 
 output "watchmaker-lx-autoscale-launch-config-log-group-name" {
   description = "Log Group Name"
-  value       = "${aws_cloudformation_stack.watchmaker-lx-autoscale.outputs["WatchmakerLaunchConfigLogGroupName"]}"
+  value       = "${lookup(aws_cloudformation_stack.watchmaker-lx-autoscale.outputs, "WatchmakerLaunchConfigLogGroupName", "")}"
 }

--- a/modules/lx-autoscale/watchmaker-lx-autoscale.template.cfn.json
+++ b/modules/lx-autoscale/watchmaker-lx-autoscale.template.cfn.json
@@ -347,7 +347,7 @@
                 }
             }
         },
-        "Version": "1.4.2"
+        "Version": "1.4.3"
     },
     "Outputs": {
         "ScaleDownScheduledAction": {

--- a/modules/lx-instance/outputs.tf
+++ b/modules/lx-instance/outputs.tf
@@ -7,10 +7,10 @@ output "watchmaker-lx-instance-stack-id" {
 
 output "watchmaker-lx-instance-id" {
   description = "Instance ID"
-  value       = "${aws_cloudformation_stack.watchmaker-lx-instance.outputs["WatchmakerInstanceId"]}"
+  value       = "${lookup(aws_cloudformation_stack.watchmaker-lx-instance.outputs, "WatchmakerInstanceId", "")}"
 }
 
 output "watchmaker-lx-instance-log-group-name" {
   description = "Log Group Name"
-  value       = "${aws_cloudformation_stack.watchmaker-lx-instance.outputs["WatchmakerInstanceLogGroupName"]}"
+  value       = "${lookup(aws_cloudformation_stack.watchmaker-lx-instance.outputs, "WatchmakerInstanceLogGroupName", "")}"
 }

--- a/modules/lx-instance/watchmaker-lx-instance.template.cfn.json
+++ b/modules/lx-instance/watchmaker-lx-instance.template.cfn.json
@@ -329,7 +329,7 @@
                 }
             }
         },
-        "Version": "1.4.2"
+        "Version": "1.4.3"
     },
     "Outputs": {
         "WatchmakerInstanceId": {

--- a/modules/win-autoscale/outputs.tf
+++ b/modules/win-autoscale/outputs.tf
@@ -17,15 +17,15 @@ output "watchmaker-win-autoscale-scale-up-scheduled-action" {
 
 output "watchmaker-win-autoscale-autoscaling-group-id" {
   description = "Autoscaling Group ID"
-  value       = "${aws_cloudformation_stack.watchmaker-win-autoscale.outputs["WatchmakerAutoScalingGroupId"]}"
+  value       = "${lookup(aws_cloudformation_stack.watchmaker-win-autoscale.outputs, "WatchmakerAutoScalingGroupId", "")}"
 }
 
 output "watchmaker-win-autoscale-launch-config-id" {
   description = "Launch Configuration ID"
-  value       = "${aws_cloudformation_stack.watchmaker-win-autoscale.outputs["WatchmakerLaunchConfigId"]}"
+  value       = "${lookup(aws_cloudformation_stack.watchmaker-win-autoscale.outputs, "WatchmakerLaunchConfigId", "")}"
 }
 
 output "watchmaker-win-autoscale-launch-config-log-group-name" {
   description = "Log Group Name"
-  value       = "${aws_cloudformation_stack.watchmaker-win-autoscale.outputs["WatchmakerLaunchConfigLogGroupName"]}"
+  value       = "${lookup(aws_cloudformation_stack.watchmaker-win-autoscale.outputs, "WatchmakerLaunchConfigLogGroupName", "")}"
 }

--- a/modules/win-autoscale/watchmaker-win-autoscale.template.cfn.json
+++ b/modules/win-autoscale/watchmaker-win-autoscale.template.cfn.json
@@ -266,7 +266,7 @@
                 }
             }
         },
-        "Version": "1.4.2"
+        "Version": "1.4.3"
     },
     "Outputs": {
         "ScaleDownScheduledAction": {

--- a/modules/win-instance/outputs.tf
+++ b/modules/win-instance/outputs.tf
@@ -7,10 +7,10 @@ output "watchmaker-win-instance-stack-id" {
 
 output "watchmaker-win-instance-id" {
   description = "Instance ID"
-  value       = "${aws_cloudformation_stack.watchmaker-win-instance.outputs["WatchmakerInstanceId"]}"
+  value       = "${lookup(aws_cloudformation_stack.watchmaker-win-instance.outputs, "WatchmakerInstanceId", "")}"
 }
 
 output "watchmaker-win-instance-log-group-name" {
   description = "Log Group Name"
-  value       = "${aws_cloudformation_stack.watchmaker-win-instance.outputs["WatchmakerInstanceLogGroupName"]}"
+  value       = "${lookup(aws_cloudformation_stack.watchmaker-win-instance.outputs, "WatchmakerInstanceLogGroupName", "")}"
 }

--- a/modules/win-instance/watchmaker-win-instance.template.cfn.json
+++ b/modules/win-instance/watchmaker-win-instance.template.cfn.json
@@ -261,7 +261,7 @@
                 }
             }
         },
-        "Version": "1.4.2"
+        "Version": "1.4.3"
     },
     "Outputs": {
         "WatchmakerInstanceId": {


### PR DESCRIPTION
When the Cloudformation stack fails, `terraform destroy` returns an error when it is refreshing the state to delete the stack.  It tries to read the `Outputs` map which has no elements.

The fix is to populate the map with empty strings so that the indexing still returns a value even though it is an empty string.