### PR TITLE
Formats appvolume just once in el7.6

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.9.0
+current_version = 1.9.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/modules/lx-autoscale/watchmaker-lx-autoscale.template.cfn.yaml
+++ b/modules/lx-autoscale/watchmaker-lx-autoscale.template.cfn.yaml
@@ -944,7 +944,7 @@ Resources:
                 - !Sub
                   - |+
                       bootcmd:
-                        - cloud-init-per instance mkfs-appvolume mkfs -t ext4 ${local_SupportsNvme}
+                        - cloud-init-per instance mkfsappvolume mkfs -t ext4 ${local_SupportsNvme}
                       mounts: 
                         - [${local_SupportsNvme}, ${AppVolumeMountPath}]
                   - local_SupportsNvme: !If [SupportsNvme, /dev/nvme1n1, /dev/xvdf]

--- a/modules/lx-autoscale/watchmaker-lx-autoscale.template.cfn.yaml
+++ b/modules/lx-autoscale/watchmaker-lx-autoscale.template.cfn.yaml
@@ -208,7 +208,7 @@ Metadata:
         default: Force Cfn Init Update
       ToggleNewInstances:
         default: Force New Instances
-  Version: 1.9.0
+  Version: 1.9.1
 Outputs:
   ScaleDownScheduledAction:
     Condition: UseScheduledAction

--- a/modules/lx-instance/watchmaker-lx-instance.template.cfn.yaml
+++ b/modules/lx-instance/watchmaker-lx-instance.template.cfn.yaml
@@ -181,7 +181,7 @@ Metadata:
     ParameterLabels:
       ToggleCfnInitUpdate:
         default: Force Cfn Init Update
-  Version: 1.9.0
+  Version: 1.9.1
 Outputs:
   WatchmakerInstanceId:
     Description: Instance ID

--- a/modules/lx-instance/watchmaker-lx-instance.template.cfn.yaml
+++ b/modules/lx-instance/watchmaker-lx-instance.template.cfn.yaml
@@ -836,7 +836,7 @@ Resources:
                 - !Sub
                   - |+
                       bootcmd:
-                        - cloud-init-per instance mkfs-appvolume mkfs -t ext4 ${local_SupportsNvme}
+                        - cloud-init-per instance mkfsappvolume mkfs -t ext4 ${local_SupportsNvme}
                       mounts: 
                         - [${local_SupportsNvme}, ${AppVolumeMountPath}]
                   - local_SupportsNvme: !If [SupportsNvme, /dev/nvme1n1, /dev/xvdf]

--- a/modules/win-autoscale/watchmaker-win-autoscale.template.cfn.yaml
+++ b/modules/win-autoscale/watchmaker-win-autoscale.template.cfn.yaml
@@ -145,7 +145,7 @@ Metadata:
         default: Force Cfn Init Update
       ToggleNewInstances:
         default: Force New Instances
-  Version: 1.9.0
+  Version: 1.9.1
 Outputs:
   ScaleDownScheduledAction:
     Condition: UseScheduledAction

--- a/modules/win-instance/watchmaker-win-instance.template.cfn.yaml
+++ b/modules/win-instance/watchmaker-win-instance.template.cfn.yaml
@@ -121,7 +121,7 @@ Metadata:
     ParameterLabels:
       ToggleCfnInitUpdate:
         default: Force Cfn Init Update
-  Version: 1.9.0
+  Version: 1.9.1
 Outputs:
   WatchmakerInstanceId:
     Description: Instance ID


### PR DESCRIPTION
Seemingly, the hyphen was triggering some shellism in the test in
cloud-init-per, when invoked via cloud-config/bootcmd.